### PR TITLE
Better handling of "sources" parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,9 +42,10 @@ export function autocomplete ({
   // build query
   const query = {
     api_key: apiKey,
-    sources,
     text
   }
+
+  if (sources !== null && sources.length > 0) query.sources = sources
 
   if (layers) {
     query.layers = layers
@@ -112,9 +113,10 @@ export function search ({
   const query = {
     api_key: apiKey,
     size,
-    sources,
     text
   }
+
+  if (sources !== null && sources.length > 0) query.sources = sources
 
   if (focusPoint) {
     const {lat, lon} = lonlat(focusPoint)

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ export function autocomplete ({
     text
   }
 
-  if (sources !== null && sources.length > 0) query.sources = sources
+  if (sources && sources.length > 0) query.sources = sources
 
   if (layers) {
     query.layers = layers
@@ -116,7 +116,7 @@ export function search ({
     text
   }
 
-  if (sources !== null && sources.length > 0) query.sources = sources
+  if (sources && sources.length > 0) query.sources = sources
 
   if (focusPoint) {
     const {lat, lon} = lonlat(focusPoint)


### PR DESCRIPTION
Minor change to only include 'sources' param in pelias request if a not-null value for 'sources' is specified in original call to 'search' or 'autocomplete'

Requested by TriMet here: https://github.com/conveyal/trimet-mod-otp/issues/62