### PR TITLE
Add fetch options for custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ service.
     -   `$0.format` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
     -   `$0.layers` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** a comma-separated list of
           [layer types](https://mapzen.com/documentation/search/autocomplete/#layers)
+    -   `$0.options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** options to pass to fetch (e.g., custom headers)
     -   `$0.sources` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?**  (optional, default `'gn,oa,osm,wof'`)
     -   `$0.text` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** query text
     -   `$0.url` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** optional URL to override Mapzen autocomplete endpoint (optional, default `'https://search.mapzen.com/v1/autocomplete'`)
@@ -120,6 +121,7 @@ service.
     -   `$0.boundary` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
     -   `$0.focusPoint` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
     -   `$0.format` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+    -   `$0.options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** options to pass to fetch (e.g., custom headers)
     -   `$0.size` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?**  (optional, default `10`)
     -   `$0.sources` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?**  (optional, default `'gn,oa,osm,wof'`)
     -   `$0.text` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The address text to query for
@@ -138,6 +140,7 @@ service.
 -   `$0` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
     -   `$0.apiKey` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The Mapzen API key
     -   `$0.format` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+    -   `$0.options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** options to pass to fetch (e.g., custom headers)
     -   `$0.point` **{lat: [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number), lon: [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)}** Point to reverse geocode
     -   `$0.url` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** optional URL to override Mapzen reverse endpoint (optional, default `'https://search.mapzen.com/v1/reverse'`)
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -17,6 +17,23 @@ describe('autocomplete', () => {
     expect(result.features[0].geometry.coordinates[0]).toEqual(-77.023104)
   })
 
+  it('should successfully autocomplete with custom headers', async () => {
+    nock('https://search.mapzen.com/', {
+      // Check for custom headers passed in below autocomplete request.
+      reqheaders: {
+        'x-api-key': headerValue => headerValue.includes('123')
+      }
+    })
+      .get(/v1\/autocomplete/)
+      .reply(200, mockSearchResult)
+
+    const result = await geocoder.autocomplete({
+      options: {headers: {'x-api-key': 'abc123'}},
+      text: '123+Main+St'
+    })
+    expect(result.features[0].geometry.coordinates[0]).toEqual(-77.023104)
+  })
+
   it('should successfully autocomplete and include query in response', async () => {
     nock('https://search.mapzen.com/')
       .get(/v1\/autocomplete/)

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ const searchUrl = `${mapzenUrl}/search`
  * @param  {boolean} $0.format
  * @param  {string} $0.layers                     a comma-separated list of
  *   {@link https://mapzen.com/documentation/search/autocomplete/#layers|layer types}
+ * @param  {Object} $0.options                    options to pass to fetch (e.g., custom headers)
  * @param  {string} [$0.sources='gn,oa,osm,wof']
  * @param  {string} $0.text                       query text
  * @param {string} [$0.url='https://search.mapzen.com/v1/autocomplete']                       optional URL to override Mapzen autocomplete endpoint
@@ -35,6 +36,7 @@ export function autocomplete ({
   focusPoint,
   format,
   layers,
+  options,
   sources = 'gn,oa,osm,wof',
   text,
   url = autocompleteUrl
@@ -77,6 +79,7 @@ export function autocomplete ({
 
   return run({
     format,
+    options,
     query,
     url
   })
@@ -92,6 +95,7 @@ export function autocomplete ({
  * @param {Object} $0.boundary
  * @param {Object} $0.focusPoint
  * @param {boolean} $0.format
+ * @param  {Object} $0.options                  options to pass to fetch (e.g., custom headers)
  * @param {number} [$0.size=10]
  * @param {string} [$0.sources='gn,oa,osm,wof']
  * @param {string} $0.text                      The address text to query for
@@ -103,6 +107,7 @@ export function search ({
   boundary,
   focusPoint,
   format,
+  options,
   size = 10,
   sources = 'gn,oa,osm,wof',
   text,
@@ -140,7 +145,7 @@ export function search ({
     }
   }
 
-  return run({format, query, url})
+  return run({format, options, query, url})
 }
 
 /**
@@ -151,6 +156,7 @@ export function search ({
  * @param {Object} $0
  * @param {string} $0.apiKey                    The Mapzen API key
  * @param {boolean} $0.format
+ * @param  {Object} $0.options                  options to pass to fetch (e.g., custom headers)
  * @param {{lat: number, lon: number}} $0.point Point to reverse geocode
  * @param {string} [$0.url='https://search.mapzen.com/v1/reverse']                     optional URL to override Mapzen reverse endpoint
  * @return {Promise}                            A Promise that'll get resolved with reverse geocode result
@@ -158,12 +164,14 @@ export function search ({
 export function reverse ({
   apiKey,
   format,
+  options,
   point,
   url = reverseUrl
 }) {
   const {lon, lat} = lonlat(point)
   return run({
     format,
+    options,
     query: {
       api_key: apiKey,
       'point.lat': lat,
@@ -175,10 +183,11 @@ export function reverse ({
 
 function run ({
   format = false,
+  options,
   query,
   url = searchUrl
 }) {
-  return fetch(`${url}?${qs.stringify(query)}`)
+  return fetch(`${url}?${qs.stringify(query)}`, options)
     .then((res) => res.json())
     .then((json) => {
       let jsonResponse = json


### PR DESCRIPTION
fix #46. This simply allows for passing fetch options from any request type (e.g., autocomplete) to where fetch is called.