### PR TITLE
Fix reverse query generation

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -211,7 +211,7 @@ function run({
   query,
   url = searchUrl
 }: PeliasFetchArgs): JSONArrayPromise {
-  return fetch(`${url}?${stringify(query)}`, options)
+  return fetch(`${url}?${stringify(query, {allowDots: true})}`, options)
     .then((res) => res.json())
     .then((json) => {
       let jsonResponse = json


### PR DESCRIPTION
Reverse queries were not formatted correctly. Passing this argument to the qs stringify function will ensure they are formatted correctly, which fixes reverse geocode queries. 